### PR TITLE
Changed path for edmcoverlay.log

### DIFF
--- a/EDMCOverlay/EDMCOverlay/EDMCOverlay.cs
+++ b/EDMCOverlay/EDMCOverlay/EDMCOverlay.cs
@@ -127,9 +127,8 @@ namespace EDMCOverlay
 
             String appdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             String edmc = System.IO.Path.Combine(appdata, "EDMarketConnector");
-            String plugins = System.IO.Path.Combine(edmc, "plugins");
 
-            Logger.Setup(System.IO.Path.Combine(plugins, "edmcoverlay.log"));
+            Logger.Setup(System.IO.Path.Combine(edmc, "edmcoverlay.log"));
             Logger.LogMessage("starting..");
             Logger.Subsystem = typeof(EDMCOverlay);
             try


### PR DESCRIPTION
Moving edmcoverlay.log outside the plugin folder into EDMC main folder. This log file interferes with the EDMC plugin loader if left in the plugin folder.