### PR TITLE
Re #16 Fix generation of massive logfile when EDMC is restarted.

### DIFF
--- a/EDMCOverlay/EDMCOverlay/OverlayJsonServer.cs
+++ b/EDMCOverlay/EDMCOverlay/OverlayJsonServer.cs
@@ -147,9 +147,10 @@ namespace EDMCOverlay
             try
             {
                 using (TcpClient client = (TcpClient) obj)
-                {
-                    StreamReader reader = new StreamReader(client.GetStream(), Encoding.UTF8);                    
-                    while (client.Connected)
+                {                    
+                    StreamReader reader = new StreamReader(client.GetStream(), Encoding.UTF8);
+                    bool lostConnection = false;           
+                    while (client.Connected && !lostConnection)
                     {                        
                         if (client.Client.Poll(100 * 1000, SelectMode.SelectRead))
                         {
@@ -164,6 +165,7 @@ namespace EDMCOverlay
                                 {
                                     // 
                                     Logger.LogMessage(String.Format("client {0} disconnected..", clientId));
+                                    lostConnection = true;                           
                                     break;  // client disconnected
                                 }
 

--- a/EDMCOverlay/EDMCOverlay/Properties/AssemblyInfo.cs
+++ b/EDMCOverlay/EDMCOverlay/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 //
 //      Major Version
 //      Minor Version 
-//      Build Number
+//      Patch Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/EDMCOverlay/Installer/Installer.vdproj
+++ b/EDMCOverlay/Installer/Installer.vdproj
@@ -34,13 +34,13 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_B7BD2F9C6D04EBF17C8E6E387DB7202D"
+        "OwnerKey" = "8:_3FBC8BAA71B74F85A4E99E577F448826"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_3FBC8BAA71B74F85A4E99E577F448826"
+        "OwnerKey" = "8:_B7BD2F9C6D04EBF17C8E6E387DB7202D"
         "MsmSig" = "8:_UNDEFINED"
         }
     }
@@ -165,6 +165,11 @@
             "AssemblyAsmDisplayName" = "8:Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
+                    "_B7BD2F9C6D04EBF17C8E6E387DB7202D"
+                    {
+                    "Name" = "8:Newtonsoft.Json.dll"
+                    "Attributes" = "3:512"
+                    }
                 }
             "SourcePath" = "8:Newtonsoft.Json.dll"
             "TargetName" = "8:"
@@ -251,15 +256,15 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:EDMC Overlay"
-        "ProductCode" = "8:{9ED00103-1D35-447F-9862-C06D8295CAA9}"
-        "PackageCode" = "8:{A3B2EA4A-BE49-47AC-A17F-AEC793CB3CBE}"
+        "ProductCode" = "8:{1F845FD7-512F-4C5F-BCF4-85B9D5ABFA72}"
+        "PackageCode" = "8:{B5F2C679-7048-4B54-9F94-1A8E446B4464}"
         "UpgradeCode" = "8:{5130A4E3-3C60-4F9B-B3A7-5602D91B03AF}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:FALSE"
-        "ProductVersion" = "8:1.0.0"
+        "ProductVersion" = "8:1.0.1"
         "Manufacturer" = "8:EDMC Overlay"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://github.com/inorton/EDMCOverlay"
@@ -275,7 +280,7 @@
         "UseSystemSearchPath" = "11:TRUE"
         "TargetPlatform" = "3:0"
         "PreBuildEvent" = "8:"
-        "PostBuildEvent" = "8:c:\\Python27\\python.exe $(ProjectDir)\\..\\signer.py f:\\MovedUserdata\\inb\\Dropbox\\Authenticode\\authenticode.pfx $(BuiltOuputPath) $(ProjectDir)\\$(Configuration)\\EDMCOverlay-1.0.0.msi --gui"
+        "PostBuildEvent" = "8:c:\\Python27\\python.exe $(ProjectDir)\\..\\signer.py f:\\MovedUserdata\\inb\\Dropbox\\Authenticode\\authenticode.pfx $(BuiltOuputPath) $(ProjectDir)\\$(Configuration)\\EDMCOverlay-1.0.1.msi --gui"
         "RunPostBuildEvent" = "3:0"
         }
         "Registry"


### PR DESCRIPTION
Fixes the issue that when the game and overlay were running, restarting EDMC would cause the
overlay server to emit never-ending log messages recording that EDMC had quit. This could continue until the disk was full or the overlay was stopped.

Special thanks to CorporalLeak and Austeregrim for helping to debug
this.