### PR TITLE
Typo fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Supported colors values are:
 Supported size values are: 
  "normal" and "large"
 
-Additionally, you may draw rectanles by setting the "shap" to "rect" and setting the "color" and/or "fill" values.
+Additionally, you may draw rectangles by setting the "shape" to "rect" and setting the "color" and/or "fill" values.
 
 ```
 {"id": "fred", "shape": "rect", "x": 100, "y": 10, "w": 30:, "h": 5, "fill": "red", "color", "#ccff00"}


### PR DESCRIPTION
"rectanles" -> "rectangles" and "shap" -> "shape" on line 68.